### PR TITLE
Reset GIF on GLUT init 

### DIFF
--- a/glut/src/ps2glut.cpp
+++ b/glut/src/ps2glut.cpp
@@ -105,6 +105,10 @@ void glutInit(int* argcp, char** argv)
         //      sceDmaReset(1);
         //      sceGsResetPath();
 
+        // Reset the GIF. OSDSYS leaves PATH3 busy, that ends up having
+        // our PATH1/2 transfers ignored by the GIF.
+        *GIF::Registers::ctrl = 1;
+
         //      sceGsResetGraph(0, SCE_GS_INTERLACE, SCE_GS_NTSC, SCE_GS_FRAME);
 
         mWarn("ps2gl library has not been initialized by the user; using default values.");


### PR DESCRIPTION
PATH3 is left waiting for data because of an issue in the kernel / OSDSYS.
This PR resets the GIF on glutInit(), clearing any previous GIF path states.

This fixes the an issue when running on PCSX2, where there would would simply be a black screen.

Fixes issue #1 most likely.
## Relies on https://github.com/ps2dev/ps2stuff/pull/1 to be merged first