### PR TITLE
Make logo example to work in PCSX2

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -20,25 +20,37 @@ jobs:
     - name: Install ps2stuff
       run: |
         git clone https://github.com/ps2dev/ps2stuff.git
-        cd ps2stuff && make clean all install
+        cd ps2stuff 
+        make -j $(getconf _NPROCESSORS_ONLN) clean
+        make -j $(getconf _NPROCESSORS_ONLN) all
+        make -j $(getconf _NPROCESSORS_ONLN) install
 
     - name: Compile project
       run: |
-        make clean all install
+        make -j $(getconf _NPROCESSORS_ONLN) clean
+        make -j $(getconf _NPROCESSORS_ONLN) all
+        make -j $(getconf _NPROCESSORS_ONLN) install
 
     - name: Compile GLUT
       run: |
-        cd glut && make clean all install
+        cd glut 
+        make -j $(getconf _NPROCESSORS_ONLN) clean
+        make -j $(getconf _NPROCESSORS_ONLN) all
+        make -j $(getconf _NPROCESSORS_ONLN) install
     
     - name: Compile examples
       run: |
         cd examples
-        # For now just box example is compiling
-        cd box && make clean all
+        # For now just box and logo example is compiling
+        cd box && make clean all && cd ..
+        cd logo && make clean all && cd ..
+
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
         name: examples
         path: |
-          examples/box/box.elf
+          examples/**/*.elf
+          examples/**/*.gl
+          examples/**/*.rtx

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ prebuilddone
 *.vo
 *.a
 *.elf
+*.orig

--- a/examples/logo/Makefile
+++ b/examples/logo/Makefile
@@ -1,5 +1,35 @@
-TARGET		= logo.elf
+EE_BIN       = logo.elf
+EE_CFLAGS   := -I$(PS2SDK)/ports/include -I../shared_code/ $(EE_CFLAGS)
+EE_CXXFLAGS := -I$(PS2SDK)/ports/include -I../shared_code/ $(EE_CXXFLAGS)
+EE_OBJS      = logo.o ../shared_code/text_stuff.o
+EE_LDFLAGS  += -L$(PS2SDK)/ports/lib
+EE_LIBS      = -lps2glut -lps2gl -lps2stuff -lpad -ldma
 
-# all the examples share the same makefile, just with a different
-# executable name..
-include ../shared_code/Makefile.examples
+ifeq ($(DEBUG), 1)
+    EE_CFLAGS   += -D_DEBUG -g -O0
+    EE_CXXFLAGS += -D_DEBUG -g -O0
+endif
+
+# Disabling warnings
+WARNING_FLAGS = -Wno-strict-aliasing -Wno-conversion-null 
+
+# VU0 code is broken so disable for now
+EE_CFLAGS   += $(WARNING_FLAGS) -DNO_VU0_VECTORS
+EE_CXXFLAGS += $(WARNING_FLAGS) -DNO_VU0_VECTORS
+
+all: $(EE_BIN)
+
+clean:
+	rm -f $(EE_BIN) $(EE_OBJS)
+
+run: $(EE_BIN)
+	ps2client -h 192.168.1.10 execee host:$(EE_BIN)
+
+reset:
+	ps2client -h 192.168.1.10 reset
+
+sim: $(EE_BIN)
+	PCSX2 --elf=$(PWD)/$(EE_BIN)
+
+include $(PS2SDK)/samples/Makefile.pref
+include $(PS2SDK)/samples/Makefile.eeglobal_cpp

--- a/examples/logo/logo.cpp
+++ b/examples/logo/logo.cpp
@@ -8,6 +8,8 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 #include "GL/gl.h"
 #include "GL/glut.h"


### PR DESCRIPTION
The generated logo.elf form artefacts in the CI is already showing the logo in the PCSX2

![image](https://user-images.githubusercontent.com/10010409/235351554-0b3844a3-4230-4cde-b117-1871e9687165.png)