### PR TITLE
Disable "Loading Renderer" message 

### DIFF
--- a/src/renderermanager.cpp
+++ b/src/renderermanager.cpp
@@ -622,7 +622,7 @@ void CRendererManager::LoadRenderer(CVifSCDmaPacket& packet)
 {
     mAssert(CurrentRenderer != NULL);
 
-    GL_FUNC_DEBUG("Loading renderer: %s\n", CurrentRenderer->renderer->GetName());
+    mDebugPrint("Loading renderer: %s\n", CurrentRenderer->renderer->GetName());
 
     CurrentRenderer->renderer->Load();
 

--- a/src/renderermanager.cpp
+++ b/src/renderermanager.cpp
@@ -622,7 +622,7 @@ void CRendererManager::LoadRenderer(CVifSCDmaPacket& packet)
 {
     mAssert(CurrentRenderer != NULL);
 
-    printf("Loading renderer: %s\n", CurrentRenderer->renderer->GetName());
+    GL_FUNC_DEBUG("Loading renderer: %s\n", CurrentRenderer->renderer->GetName());
 
     CurrentRenderer->renderer->Load();
 


### PR DESCRIPTION
Disable message when loading a new renderer, less I/O, more performance :p
That message will appear when DEBUG mode is used.