### PR TITLE
Updated display list manager to support custom primitive types

### DIFF
--- a/include/ps2gl/dlgmanager.h
+++ b/include/ps2gl/dlgmanager.h
@@ -34,7 +34,7 @@ public:
     CDListGeomManager(CGLContext& context);
     virtual ~CDListGeomManager() {}
 
-    void PrimChanged(unsigned char prim);
+    void PrimChanged(GLenum prim);
 
     // user state
 

--- a/src/dlgmanager.cpp
+++ b/src/dlgmanager.cpp
@@ -338,10 +338,10 @@ public:
 };
 
 class CUpdatePrimCmd : public CDListCmd {
-    unsigned char Prim;
+    GLenum Prim;
 
 public:
-    CUpdatePrimCmd(unsigned char prim)
+    CUpdatePrimCmd(GLenum prim)
         : Prim(prim)
     {
     }
@@ -352,7 +352,7 @@ public:
     }
 };
 
-void CDListGeomManager::PrimChanged(unsigned char prim)
+void CDListGeomManager::PrimChanged(GLenum prim)
 {
     GLContext.PrimChanged();
     GLContext.GetDListManager().GetOpenDList() += CUpdatePrimCmd(prim);


### PR DESCRIPTION
Before, the `CUpdatePrimCmd` command wasn't wide enough to support custom primitive types in display lists. Custom primitive types require the 31st bit be set and the CUpdatePrimCmd only held an 8 bit wide command, so I made the command wider.